### PR TITLE
Upgrade dependencies, fix TTY for recent Node.js versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,3 @@ insert_final_newline = true
 [{package.json,*.yml}]
 indent_style = space
 indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.js text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
-*.js text eol=lf
+* text=auto eol=lf

--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,3 @@
+github: sindresorhus
+open_collective: sindresorhus
+custom: https://sindresorhus.com/donate

--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,3 +1,4 @@
 github: sindresorhus
 open_collective: sindresorhus
+tidelift: npm/get-stdin
 custom: https://sindresorhus.com/donate

--- a/.github/security.md
+++ b/.github/security.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+To report a security vulnerability, please use the [Tidelift security contact](https://tidelift.com/security). Tidelift will coordinate the fix and disclosure.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '8'
   - '6'
   - '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '5'
+  - '6'
   - '4'
   - '0.12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: false
 language: node_js
 node_js:
+  - '10'
   - '8'
-  - '6'
-  - '4'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+/// <reference types="node"/>
+
+declare const getStdin: {
+	/**
+	Get [`stdin`](https://nodejs.org/api/process.html#process_process_stdin) as a `string`.
+
+	@returns A promise that is resolved when the `end` event fires on the `stdin` stream, indicating that there is no more data to be read. In a TTY context, an empty `string` is returned.
+
+	@example
+	```
+	// example.ts
+	import getStdin = require('get-stdin');
+
+	(async () => {
+		console.log(await getStdin());
+		//=> 'unicorns'
+	})
+
+	// $ echo unicorns | ts-node example.ts
+	// unicorns
+	```
+	*/
+	(): Promise<string>;
+
+	/**
+	Get [`stdin`](https://nodejs.org/api/process.html#process_process_stdin) as a `Buffer`.
+
+	@returns A promise that is resolved when the `end` event fires on the `stdin` stream, indicating that there is no more data to be read. In a TTY context, an empty `Buffer` is returned.
+	*/
+	buffer(): Promise<Buffer>;
+};
+
+export = getStdin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,9 @@
 /// <reference types="node"/>
 
 interface Options {
+	/**
+	Enables reading from TTY, which can be anded by ^d or ^z.
+	*/
 	tty?: boolean;
 }
 
@@ -15,7 +18,7 @@ declare const getStdin: {
 	@example
 	```
 	// example.ts
-	import getStdin = require('get-stdin');
+	import getStdin = require('get-stdin-with-tty');
 
 	(async () => {
 		console.log(await getStdin({ tty: true }));

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
-const stdin = process.stdin;
+const {stdin} = process;
 
 module.exports = () => {
-	let ret = '';
+	let result = '';
 
 	return new Promise(resolve => {
 		if (stdin.isTTY) {
-			resolve(ret);
+			resolve(result);
 			return;
 		}
 
@@ -16,19 +16,19 @@ module.exports = () => {
 			let chunk;
 
 			while ((chunk = stdin.read())) {
-				ret += chunk;
+				result += chunk;
 			}
 		});
 
 		stdin.on('end', () => {
-			resolve(ret);
+			resolve(result);
 		});
 	});
 };
 
 module.exports.buffer = () => {
-	const ret = [];
-	let len = 0;
+	const result = [];
+	let length = 0;
 
 	return new Promise(resolve => {
 		if (stdin.isTTY) {
@@ -40,13 +40,13 @@ module.exports.buffer = () => {
 			let chunk;
 
 			while ((chunk = stdin.read())) {
-				ret.push(chunk);
-				len += chunk.length;
+				result.push(chunk);
+				length += chunk.length;
 			}
 		});
 
 		stdin.on('end', () => {
-			resolve(Buffer.concat(ret, len));
+			resolve(Buffer.concat(result, length));
 		});
 	});
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.buffer = () => {
 
 	return new Promise(resolve => {
 		if (stdin.isTTY) {
-			resolve(new Buffer('')); // eslint-disable-line unicorn/no-new-buffer
+			resolve(Buffer.concat([]));
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
-var stdin = process.stdin;
+const stdin = process.stdin;
 
-module.exports = function () {
-	var ret = '';
+module.exports = () => {
+	let ret = '';
 
-	return new Promise(function (resolve) {
+	return new Promise(resolve => {
 		if (stdin.isTTY) {
 			resolve(ret);
 			return;
@@ -12,32 +12,32 @@ module.exports = function () {
 
 		stdin.setEncoding('utf8');
 
-		stdin.on('readable', function () {
-			var chunk;
+		stdin.on('readable', () => {
+			let chunk;
 
 			while ((chunk = stdin.read())) {
 				ret += chunk;
 			}
 		});
 
-		stdin.on('end', function () {
+		stdin.on('end', () => {
 			resolve(ret);
 		});
 	});
 };
 
-module.exports.buffer = function () {
-	var ret = [];
-	var len = 0;
+module.exports.buffer = () => {
+	const ret = [];
+	let len = 0;
 
-	return new Promise(function (resolve) {
+	return new Promise(resolve => {
 		if (stdin.isTTY) {
 			resolve(new Buffer(''));
 			return;
 		}
 
-		stdin.on('readable', function () {
-			var chunk;
+		stdin.on('readable', () => {
+			let chunk;
 
 			while ((chunk = stdin.read())) {
 				ret.push(chunk);
@@ -45,7 +45,7 @@ module.exports.buffer = function () {
 			}
 		});
 
-		stdin.on('end', function () {
+		stdin.on('end', () => {
 			resolve(Buffer.concat(ret, len));
 		});
 	});

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.buffer = () => {
 
 	return new Promise(resolve => {
 		if (stdin.isTTY) {
-			resolve(new Buffer(''));
+			resolve(new Buffer('')); // eslint-disable-line unicorn/no-new-buffer
 			return;
 		}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,5 @@
+import {expectType} from 'tsd';
+import getStdin = require('.');
+
+expectType<Promise<string>>(getStdin());
+expectType<Promise<Buffer>>(getStdin.buffer());

--- a/license
+++ b/license
@@ -1,21 +1,9 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
   "devDependencies": {
     "ava": "*",
     "xo": "*"
-  },
-  "xo": {
-    "esnext": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "get-stdin",
-	"version": "6.0.0",
+	"version": "7.0.0",
 	"description": "Get stdin as a string or buffer",
 	"license": "MIT",
 	"repository": "sindresorhus/get-stdin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "get-stdin",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"description": "Get stdin as a string or buffer",
 	"license": "MIT",
 	"repository": "sindresorhus/get-stdin",

--- a/package.json
+++ b/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "get-stdin",
-  "version": "5.0.1",
-  "description": "Get stdin as a string or buffer",
-  "license": "MIT",
-  "repository": "sindresorhus/get-stdin",
-  "author": {
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  },
-  "engines": {
-    "node": ">=4"
-  },
-  "scripts": {
-    "test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js"
-  },
-  "files": [
-    "index.js"
-  ],
-  "keywords": [
-    "std",
-    "stdin",
-    "stdio",
-    "concat",
-    "buffer",
-    "stream",
-    "process",
-    "read"
-  ],
-  "devDependencies": {
-    "ava": "*",
-    "xo": "*"
-  }
+	"name": "get-stdin",
+	"version": "5.0.1",
+	"description": "Get stdin as a string or buffer",
+	"license": "MIT",
+	"repository": "sindresorhus/get-stdin",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "sindresorhus.com"
+	},
+	"engines": {
+		"node": ">=4"
+	},
+	"scripts": {
+		"test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js"
+	},
+	"files": [
+		"index.js"
+	],
+	"keywords": [
+		"std",
+		"stdin",
+		"stdio",
+		"concat",
+		"buffer",
+		"stream",
+		"process",
+		"read"
+	],
+	"devDependencies": {
+		"ava": "*",
+		"xo": "*"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js"
+		"test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js && tsd"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"std",
@@ -29,7 +30,10 @@
 		"read"
 	],
 	"devDependencies": {
-		"ava": "*",
-		"xo": "*"
+		"@types/node": "^11.13.4",
+		"ava": "^1.4.1",
+		"delay": "^4.2.0",
+		"tsd": "^0.7.2",
+		"xo": "^0.24.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js"
@@ -30,7 +30,9 @@
   ],
   "devDependencies": {
     "ava": "*",
-    "buffer-equals": "^1.0.3",
     "xo": "*"
+  },
+  "xo": {
+    "esnext": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.12.0"
   },
   "scripts": {
-    "test": "xo && ava test.js && echo unicorns | node test-real.js"
+    "test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js"
   },
   "files": [
     "index.js"
@@ -29,7 +29,7 @@
     "read"
   ],
   "devDependencies": {
-    "ava": "^0.2.0",
+    "ava": "*",
     "buffer-equals": "^1.0.3",
     "xo": "*"
   }

--- a/readme.md
+++ b/readme.md
@@ -52,4 +52,4 @@ In a TTY context, a promise that resolves to an empty buffer is returned.
 
 ## License
 
-MIT © [Sindre Sorhus](http://sindresorhus.com)
+MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ const getStdin = require('get-stdin');
 (async () => {
 	console.log(await getStdin());
 	//=> 'unicorns'
-})
+})();
 ```
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ## Install
 
 ```
-$ npm install --save get-stdin
+$ npm install get-stdin
 ```
 
 
@@ -34,13 +34,13 @@ Both methods returns a promise that is resolved when the `end` event fires on th
 
 ### getStdin()
 
-Get `stdin` as a string.
+Get `stdin` as a `string`.
 
 In a TTY context, a promise that resolves to an empty string is returned.
 
 ### getStdin.buffer()
 
-Get `stdin` as a buffer.
+Get `stdin` as a `Buffer`.
 
 In a TTY context, a promise that resolves to an empty buffer is returned.
 

--- a/readme.md
+++ b/readme.md
@@ -16,10 +16,10 @@ $ npm install get-stdin
 // example.js
 const getStdin = require('get-stdin');
 
-getStdin().then(str => {
-	console.log(str);
+(async () => {
+	console.log(await getStdin());
 	//=> 'unicorns'
-});
+})
 ```
 
 ```
@@ -36,13 +36,13 @@ Both methods returns a promise that is resolved when the `end` event fires on th
 
 Get `stdin` as a `string`.
 
-In a TTY context, a promise that resolves to an empty string is returned.
+In a TTY context, a promise that resolves to an empty `string` is returned.
 
 ### getStdin.buffer()
 
 Get `stdin` as a `Buffer`.
 
-In a TTY context, a promise that resolves to an empty buffer is returned.
+In a TTY context, a promise that resolves to an empty `Buffer` is returned.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,14 @@ In a TTY context, a promise that resolves to an empty `Buffer` is returned.
 - [get-stream](https://github.com/sindresorhus/get-stream) - Get a stream as a string or buffer
 
 
-## License
+---
 
-MIT © [Sindre Sorhus](https://sindresorhus.com)
+<div align="center">
+	<b>
+		<a href="https://tidelift.com/subscription/pkg/npm-get-stdin?utm_source=npm-get-stdin&utm_medium=referral&utm_campaign=readme">Get professional support for this package with a Tidelift subscription</a>
+	</b>
+	<br>
+	<sub>
+		Tidelift helps make open source sustainable for maintainers while giving companies<br>assurances about security, maintenance, and licensing for their dependencies.
+	</sub>
+</div>

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -6,15 +6,15 @@ test.serial('get stdin', async t => {
 	process.stdin.isTTY = false;
 
 	const promise = m.buffer();
-	process.stdin.push(new Buffer('uni'));
-	process.stdin.push(new Buffer('corns'));
+	process.stdin.push(Buffer.from('uni'));
+	process.stdin.push(Buffer.from('corns'));
 	process.stdin.emit('end');
 	const data = await promise;
-	t.true(data.equals(new Buffer('unicorns')));
+	t.true(data.equals(Buffer.from('unicorns')));
 	t.is(data.toString(), 'unicorns');
 });
 
 test.serial('get empty buffer when no stdin', async t => {
 	process.stdin.isTTY = true;
-	t.true((await m.buffer()).equals(new Buffer('')));
+	t.true((await m.buffer()).equals(Buffer.from('')));
 });

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -1,0 +1,21 @@
+import test from 'ava';
+import bufferEquals from 'buffer-equals';
+import fn from './';
+
+test.serial('get stdin', async t => {
+	t.plan(2);
+	process.stdin.isTTY = false;
+
+	const promise = fn.buffer();
+	process.stdin.push(new Buffer('uni'));
+	process.stdin.push(new Buffer('corns'));
+	process.stdin.emit('end');
+	const data = await promise;
+	t.true(bufferEquals(data, new Buffer('unicorns')));
+	t.is(data.toString(), 'unicorns');
+});
+
+test.serial('get empty buffer when no stdin', async t => {
+	process.stdin.isTTY = true;
+	t.true(bufferEquals(await fn.buffer(), new Buffer('')));
+});

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test.serial('get stdin', async t => {
 	t.plan(2);

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -1,21 +1,20 @@
 import test from 'ava';
-import bufferEquals from 'buffer-equals';
-import fn from './';
+import m from './';
 
 test.serial('get stdin', async t => {
 	t.plan(2);
 	process.stdin.isTTY = false;
 
-	const promise = fn.buffer();
+	const promise = m.buffer();
 	process.stdin.push(new Buffer('uni'));
 	process.stdin.push(new Buffer('corns'));
 	process.stdin.emit('end');
 	const data = await promise;
-	t.true(bufferEquals(data, new Buffer('unicorns')));
+	t.true(data.equals(new Buffer('unicorns')));
 	t.is(data.toString(), 'unicorns');
 });
 
 test.serial('get empty buffer when no stdin', async t => {
 	process.stdin.isTTY = true;
-	t.true(bufferEquals(await fn.buffer(), new Buffer('')));
+	t.true((await m.buffer()).equals(new Buffer('')));
 });

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -1,20 +1,22 @@
-import test from 'ava';
-import m from '.';
+import {serial as test} from 'ava';
+import delay from 'delay';
+import getStdin from '.';
 
-test.serial('get stdin', async t => {
-	t.plan(2);
+test('get stdin', async t => {
 	process.stdin.isTTY = false;
 
-	const promise = m.buffer();
+	const promise = getStdin.buffer();
 	process.stdin.push(Buffer.from('uni'));
 	process.stdin.push(Buffer.from('corns'));
+	await delay(1);
 	process.stdin.emit('end');
+
 	const data = await promise;
 	t.true(data.equals(Buffer.from('unicorns')));
 	t.is(data.toString(), 'unicorns');
 });
 
-test.serial('get empty buffer when no stdin', async t => {
+test('get empty buffer when no stdin', async t => {
 	process.stdin.isTTY = true;
-	t.true((await m.buffer()).equals(Buffer.from('')));
+	t.true((await getStdin.buffer()).equals(Buffer.from('')));
 });

--- a/test-real.js
+++ b/test-real.js
@@ -1,6 +1,7 @@
 'use strict';
 const getStdin = require('.');
 
-getStdin().then(data => {
-	process.exit(data ? 0 : 1); // eslint-disable-line unicorn/no-process-exit
-});
+(async () => {
+	const stdin = await getStdin();
+	process.exit(stdin ? 0 : 1); // eslint-disable-line unicorn/no-process-exit
+})();

--- a/test-real.js
+++ b/test-real.js
@@ -1,6 +1,6 @@
 'use strict';
-const m = require('.');
+const getStdin = require('.');
 
-m().then(data => {
+getStdin().then(data => {
 	process.exit(data ? 0 : 1); // eslint-disable-line unicorn/no-process-exit
 });

--- a/test-real.js
+++ b/test-real.js
@@ -1,6 +1,6 @@
 'use strict';
-var fn = require('./');
+const m = require('./');
 
-fn().then(function (data) {
-	process.exit(data ? 0 : 1); // eslint-disable-line xo/no-process-exit
+m().then(data => {
+	process.exit(data ? 0 : 1); // eslint-disable-line unicorn/no-process-exit
 });

--- a/test-real.js
+++ b/test-real.js
@@ -2,5 +2,5 @@
 var fn = require('./');
 
 fn().then(function (data) {
-	process.exit(data ? 0 : 1);
+	process.exit(data ? 0 : 1); // eslint-disable-line xo/no-process-exit
 });

--- a/test-real.js
+++ b/test-real.js
@@ -1,5 +1,5 @@
 'use strict';
-const m = require('./');
+const m = require('.');
 
 m().then(data => {
 	process.exit(data ? 0 : 1); // eslint-disable-line unicorn/no-process-exit

--- a/test.js
+++ b/test.js
@@ -1,39 +1,17 @@
 import test from 'ava';
-import bufferEquals from 'buffer-equals';
 import fn from './';
 
 test.serial('get stdin', async t => {
+	t.plan(1);
 	process.stdin.isTTY = false;
-
-	setImmediate(() => {
-		process.stdin.push('unicorns');
-		process.stdin.emit('end');
-	});
-
-	t.is((await fn()).trim(), 'unicorns');
+	const promise = fn();
+	process.stdin.push('uni');
+	process.stdin.push('corns');
+	process.stdin.emit('end');
+	t.is((await promise).trim(), 'unicorns');
 });
 
 test.serial('get empty string when no stdin', async t => {
 	process.stdin.isTTY = true;
 	t.is(await fn(), '');
-});
-
-test.serial('get stdin as a buffer', t => {
-	process.stdin.isTTY = false;
-
-	const promise = fn.buffer(data => {
-		t.true(bufferEquals(data, new Buffer('unicorns')));
-		t.is(data.toString().trim(), 'unicorns');
-	});
-
-	process.stdin.push(new Buffer('unicorns'));
-	process.stdin.emit('end');
-
-	return promise;
-});
-
-test.serial('get empty buffer when no stdin', async t => {
-	process.stdin.isTTY = true;
-
-	t.true(bufferEquals(await fn.buffer(), new Buffer('')));
 });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test.serial('get stdin', async t => {
 	t.plan(1);

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
 import test from 'ava';
-import fn from './';
+import m from './';
 
 test.serial('get stdin', async t => {
 	t.plan(1);
 	process.stdin.isTTY = false;
-	const promise = fn();
+	const promise = m();
 	process.stdin.push('uni');
 	process.stdin.push('corns');
 	process.stdin.emit('end');
@@ -13,5 +13,5 @@ test.serial('get stdin', async t => {
 
 test.serial('get empty string when no stdin', async t => {
 	process.stdin.isTTY = true;
-	t.is(await fn(), '');
+	t.is(await m(), '');
 });

--- a/test.js
+++ b/test.js
@@ -1,17 +1,20 @@
-import test from 'ava';
-import m from '.';
+import {serial as test} from 'ava';
+import delay from 'delay';
+import getStdin from '.';
 
-test.serial('get stdin', async t => {
-	t.plan(1);
+test('get stdin', async t => {
 	process.stdin.isTTY = false;
-	const promise = m();
+	const promise = getStdin();
+
 	process.stdin.push('uni');
 	process.stdin.push('corns');
+	await delay(1);
 	process.stdin.emit('end');
+
 	t.is((await promise).trim(), 'unicorns');
 });
 
-test.serial('get empty string when no stdin', async t => {
+test('get empty string when no stdin', async t => {
 	process.stdin.isTTY = true;
-	t.is(await m(), '');
+	t.is(await getStdin(), '');
 });


### PR DESCRIPTION
* Fix a problem with the new Node.js versions, which do not send the EOF code at the beginning of a new chunk.
 * Let unit tests use ESM.
 * Upgrade all NPM dependencies.
 * Apply changes according to the new coding standard requirements.
 * Bump the version number to 6.0.0.